### PR TITLE
Change Text filter to F.text

### DIFF
--- a/book_src/fsm.md
+++ b/book_src/fsm.md
@@ -291,8 +291,8 @@ async def food_size_chosen_incorrectly(message: Message):
 Обе функции сбрасывают состояние и данные, и убирают обычную клавиатуру, если вдруг она есть:
 
 ```python title="handlers/common.py"
-from aiogram import Router
-from aiogram.filters import Command, Text
+from aiogram import F, Router
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.types import Message, ReplyKeyboardRemove
 
@@ -310,7 +310,7 @@ async def cmd_start(message: Message, state: FSMContext):
 
 
 @router.message(Command(commands=["cancel"]))
-@router.message(Text(text="отмена", ignore_case=True))
+@router.message(F.text.lower() == "отмена")
 async def cmd_cancel(message: Message, state: FSMContext):
     await state.clear()
     await message.answer(

--- a/code/07_fsm/handlers/common.py
+++ b/code/07_fsm/handlers/common.py
@@ -1,12 +1,12 @@
-from aiogram import Router
-from aiogram.filters import Command, Text
+from aiogram import F, Router
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.types import Message, ReplyKeyboardRemove
 
 router = Router()
 
 
-@router.message(Command("start"))
+@router.message(Command(commands=["start"]))
 async def cmd_start(message: Message, state: FSMContext):
     await state.clear()
     await message.answer(
@@ -16,8 +16,8 @@ async def cmd_start(message: Message, state: FSMContext):
     )
 
 
-@router.message(Command("cancel"))
-@router.message(Text(text="отмена", ignore_case=True))
+@router.message(Command(commands=["cancel"]))
+@router.message(F.text.lower() == "отмена")
 async def cmd_cancel(message: Message, state: FSMContext):
     await state.clear()
     await message.answer(


### PR DESCRIPTION
Appreciate your work! Thank you for this guide 

Since Text filter was deprecated in [3.0.0b8](https://github.com/aiogram/aiogram/blob/dev-3.x/CHANGES.rst#deprecations-and-removals-1) I changed it to F.text
Updated handlers/common.py example as well

Best regards, Mark