### PR TITLE
BaseSettings import fix due to library update

### DIFF
--- a/book_src/quickstart.md
+++ b/book_src/quickstart.md
@@ -260,7 +260,8 @@ async def cmd_show_list(message: types.Message, mylist: list[int]):
 Итак, создадим рядом с `bot.py` отдельный файл `config_reader.py` со следующим содержимым
 
 ```python title="config_reader.py"
-from pydantic import BaseSettings, SecretStr
+from pydantic_settings import BaseSettings
+from pydantic import SecretStr
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
Из-за обновления либы не корректно импортировался BaseSettings, что вызывало ошибку:
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.3/migration/#basesettings-has-moved-to-pydantic-settings for more details.